### PR TITLE
Enabling support for HTML5 input type="time"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ if (something) {
 | fromnow | 0 | set default time to * milliseconds from now (using with default = 'now' or default = Date) |
 | hourstep | 1 | allow to multi increment the hour |
 | minutestep | 1 | allow to multi increment the minute |
+| ampmSubmit | false | allow submit with AM and PM buttons instead of the minute selection/picker |
+| addonOnly | false	| disables the focus and click triggers on the input field (to allow delegation to native pickers) |
 | init | | callback function triggered after the colorpicker has been initiated |
 | beforeShow | | callback function triggered before popup is shown |
 | afterShow | | callback function triggered after popup is shown |

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -719,6 +719,7 @@
 		this.hide();
 		var last = this.input.prop('value'),
 			outHours = this.hours,
+			value = ':' + leadingZero(this.minutes);
 		
 		if (this.isHTML5 && this.options.twelvehour) {
 			if (this.hours < 12 && this.amOrPm === 'PM') {
@@ -729,6 +730,7 @@
 			}
 		}
 		
+		value = leadingZero(outHours) + value;
 		
 		if (!this.isHTML5 && this.options.twelvehour) {
 			value = value + this.amOrPm;

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -94,6 +94,7 @@
 			minutesView = popover.find('.clockpicker-minutes'),
 			amPmBlock = popover.find('.clockpicker-am-pm-block'),
 			isInput = element.prop('tagName') === 'INPUT',
+			isHTML5 = element.prop('type') === 'time',
 			input = isInput ? element : element.find('input'),
 			addon = element.find('.input-group-addon'),
 			self = this,
@@ -108,6 +109,7 @@
 		this.isShown = false;
 		this.currentView = 'hours';
 		this.isInput = isInput;
+		this.isHTML5 = isHTML5;
 		this.input = input;
 		this.addon = addon;
 		this.popover = popover;
@@ -168,7 +170,9 @@
 		this.spanMinutes.click($.proxy(this.toggleView, this, 'minutes'));
 
 		// Show or toggle
-		input.on('focus.clockpicker click.clockpicker', $.proxy(this.show, this));
+		if (!options.addonOnly) {
+			input.on('focus.clockpicker click.clockpicker', $.proxy(this.show, this));
+		}
 		addon.on('click.clockpicker', $.proxy(this.toggle, this));
 
 		// Build ticks
@@ -371,7 +375,8 @@
 		vibrate: true,		// vibrate the device when dragging clock hand
 		hourstep: 1,		// allow to multi increment the hour
 		minutestep: 1,		// allow to multi increment the minute
-		ampmSubmit: false	// allow submit with AM and PM buttons instead of the minute selection/picker
+		ampmSubmit: false,	// allow submit with AM and PM buttons instead of the minute selection/picker
+		addonOnly: false	// only open on clicking on the input-addon
 	};
 
 	// Show or hide popover
@@ -713,8 +718,10 @@
 		raiseCallback(this.options.beforeDone);
 		this.hide();
 		var last = this.input.prop('value'),
+			//outHours = (this.options.isHTML5 && this.options.twelvehour && hours < 12 && this.amOrPm === 'PM') ? 12 + this.hours : this.hours,
 			value = leadingZero(this.hours) + ':' + leadingZero(this.minutes);
-		if  (this.options.twelvehour) {
+		
+		if (!this.options.isHTML5 && this.options.twelvehour) {
 			value = value + this.amOrPm;
 		}
 		

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -632,7 +632,7 @@
 		if (isHours) {
 			value *= options.hourstep;
 
-			if (! options.twelvehour && ! inner) {
+			if (! options.twelvehour && (!inner)==(value>0)) {
 				value += 12;
 			}
 			if (options.twelvehour && value === 0) {

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -718,8 +718,17 @@
 		raiseCallback(this.options.beforeDone);
 		this.hide();
 		var last = this.input.prop('value'),
-			outHours = (this.isHTML5 && this.options.twelvehour && this.hours < 12 && this.amOrPm === 'PM') ? 12+this.hours : this.hours,
-			value = leadingZero(outHours) + ':' + leadingZero(this.minutes);
+			outHours = this.hours,
+		
+		if (this.isHTML5 && this.options.twelvehour) {
+			if (this.hours < 12 && this.amOrPm === 'PM') {
+				outHours += 12;
+			}
+			if (this.hours === 12 && this.amOrPm === 'AM') {
+				outHours = 0;
+			}
+		}
+		
 		
 		if (!this.isHTML5 && this.options.twelvehour) {
 			value = value + this.amOrPm;

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -94,8 +94,8 @@
 			minutesView = popover.find('.clockpicker-minutes'),
 			amPmBlock = popover.find('.clockpicker-am-pm-block'),
 			isInput = element.prop('tagName') === 'INPUT',
-			isHTML5 = element.prop('type') === 'time',
 			input = isInput ? element : element.find('input'),
+			isHTML5 = input.prop('type') === 'time',
 			addon = element.find('.input-group-addon'),
 			self = this,
 			timer;
@@ -718,10 +718,10 @@
 		raiseCallback(this.options.beforeDone);
 		this.hide();
 		var last = this.input.prop('value'),
-			//outHours = (this.options.isHTML5 && this.options.twelvehour && hours < 12 && this.amOrPm === 'PM') ? 12 + this.hours : this.hours,
-			value = leadingZero(this.hours) + ':' + leadingZero(this.minutes);
+			outHours = (this.isHTML5 && this.options.twelvehour && this.hours < 12 && this.amOrPm === 'PM') ? 12+this.hours : this.hours,
+			value = leadingZero(outHours) + ':' + leadingZero(this.minutes);
 		
-		if (!this.options.isHTML5 && this.options.twelvehour) {
+		if (!this.isHTML5 && this.options.twelvehour) {
 			value = value + this.amOrPm;
 		}
 		


### PR DESCRIPTION
The project I'm working on required a time picker that can support HTML5 time input and delegate itself to native controls if requested. I've added simple detection to determine the output format and an option to not bind on input focus (useful for mobile devices that have their own native time pickers).

I've also fixed a bug in which the hours 12 and 00 would swap values when the hour hand was between 12 and 1 (logically 12 and 00 should be in opposite positions, but that's something for another day)
